### PR TITLE
[2022/11/11] feat/detailViewController >> DetailViewController 전환 및 데이터호출 구현

### DIFF
--- a/ItBookSearchApp/ItBookSearchApp.xcodeproj/project.pbxproj
+++ b/ItBookSearchApp/ItBookSearchApp.xcodeproj/project.pbxproj
@@ -29,7 +29,7 @@
 		55746007291E690B00414462 /* ItBookDetailManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55746006291E690B00414462 /* ItBookDetailManagerTests.swift */; };
 		5574600A291E698300414462 /* Securing_DevOps_ItBookDetail.json in Resources */ = {isa = PBXBuildFile; fileRef = 55746009291E698300414462 /* Securing_DevOps_ItBookDetail.json */; };
 		5574600C291E6DFE00414462 /* FileWeb_Scraping_with_Python_ItBookDetail.json in Resources */ = {isa = PBXBuildFile; fileRef = 5574600B291E6DFE00414462 /* FileWeb_Scraping_with_Python_ItBookDetail.json */; };
-		55746012291E848D00414462 /* ViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55746011291E848D00414462 /* ViewControllerTests.swift */; };
+		55746012291E848D00414462 /* SearchViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55746011291E848D00414462 /* SearchViewControllerTests.swift */; };
 		55746014291E8EF600414462 /* SwiftItBookStore.json in Resources */ = {isa = PBXBuildFile; fileRef = 55746013291E8EF600414462 /* SwiftItBookStore.json */; };
 		55746016291EBBA000414462 /* Swift2ItBookStore.json in Resources */ = {isa = PBXBuildFile; fileRef = 55746015291EBBA000414462 /* Swift2ItBookStore.json */; };
 		55746018291EBEBE00414462 /* Swift50ItBookStore.json in Resources */ = {isa = PBXBuildFile; fileRef = 55746017291EBEBE00414462 /* Swift50ItBookStore.json */; };
@@ -80,7 +80,7 @@
 		55746006291E690B00414462 /* ItBookDetailManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItBookDetailManagerTests.swift; sourceTree = "<group>"; };
 		55746009291E698300414462 /* Securing_DevOps_ItBookDetail.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Securing_DevOps_ItBookDetail.json; sourceTree = "<group>"; };
 		5574600B291E6DFE00414462 /* FileWeb_Scraping_with_Python_ItBookDetail.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = FileWeb_Scraping_with_Python_ItBookDetail.json; sourceTree = "<group>"; };
-		55746011291E848D00414462 /* ViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerTests.swift; sourceTree = "<group>"; };
+		55746011291E848D00414462 /* SearchViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewControllerTests.swift; sourceTree = "<group>"; };
 		55746013291E8EF600414462 /* SwiftItBookStore.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = SwiftItBookStore.json; sourceTree = "<group>"; };
 		55746015291EBBA000414462 /* Swift2ItBookStore.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Swift2ItBookStore.json; sourceTree = "<group>"; };
 		55746017291EBEBE00414462 /* Swift50ItBookStore.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Swift50ItBookStore.json; sourceTree = "<group>"; };
@@ -151,7 +151,7 @@
 		55745FA3291972B000414462 /* ItBookSearchAppTests */ = {
 			isa = PBXGroup;
 			children = (
-				55746011291E848D00414462 /* ViewControllerTests.swift */,
+				55746011291E848D00414462 /* SearchViewControllerTests.swift */,
 				5574600F291E7C5700414462 /* ItBookAPITests */,
 			);
 			path = ItBookSearchAppTests;
@@ -384,7 +384,7 @@
 				55745FFD291D71DA00414462 /* JsonLoader.swift in Sources */,
 				55745FF9291D64C400414462 /* MockURLSessionDataTask.swift in Sources */,
 				55745FF7291D63F400414462 /* MockURLSession.swift in Sources */,
-				55746012291E848D00414462 /* ViewControllerTests.swift in Sources */,
+				55746012291E848D00414462 /* SearchViewControllerTests.swift in Sources */,
 				55746007291E690B00414462 /* ItBookDetailManagerTests.swift in Sources */,
 				55745FFF291D80CB00414462 /* ItBookStoreManagerTests.swift in Sources */,
 			);

--- a/ItBookSearchApp/ItBookSearchApp.xcodeproj/project.pbxproj
+++ b/ItBookSearchApp/ItBookSearchApp.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		55746014291E8EF600414462 /* SwiftItBookStore.json in Resources */ = {isa = PBXBuildFile; fileRef = 55746013291E8EF600414462 /* SwiftItBookStore.json */; };
 		55746016291EBBA000414462 /* Swift2ItBookStore.json in Resources */ = {isa = PBXBuildFile; fileRef = 55746015291EBBA000414462 /* Swift2ItBookStore.json */; };
 		55746018291EBEBE00414462 /* Swift50ItBookStore.json in Resources */ = {isa = PBXBuildFile; fileRef = 55746017291EBEBE00414462 /* Swift50ItBookStore.json */; };
+		5574601A291EDBBE00414462 /* DetailViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55746019291EDBBE00414462 /* DetailViewControllerTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -84,6 +85,7 @@
 		55746013291E8EF600414462 /* SwiftItBookStore.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = SwiftItBookStore.json; sourceTree = "<group>"; };
 		55746015291EBBA000414462 /* Swift2ItBookStore.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Swift2ItBookStore.json; sourceTree = "<group>"; };
 		55746017291EBEBE00414462 /* Swift50ItBookStore.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Swift50ItBookStore.json; sourceTree = "<group>"; };
+		55746019291EDBBE00414462 /* DetailViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewControllerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -152,6 +154,7 @@
 			isa = PBXGroup;
 			children = (
 				55746011291E848D00414462 /* SearchViewControllerTests.swift */,
+				55746019291EDBBE00414462 /* DetailViewControllerTests.swift */,
 				5574600F291E7C5700414462 /* ItBookAPITests */,
 			);
 			path = ItBookSearchAppTests;
@@ -385,6 +388,7 @@
 				55745FF9291D64C400414462 /* MockURLSessionDataTask.swift in Sources */,
 				55745FF7291D63F400414462 /* MockURLSession.swift in Sources */,
 				55746012291E848D00414462 /* SearchViewControllerTests.swift in Sources */,
+				5574601A291EDBBE00414462 /* DetailViewControllerTests.swift in Sources */,
 				55746007291E690B00414462 /* ItBookDetailManagerTests.swift in Sources */,
 				55745FFF291D80CB00414462 /* ItBookStoreManagerTests.swift in Sources */,
 			);

--- a/ItBookSearchApp/ItBookSearchApp/DetailViewController.swift
+++ b/ItBookSearchApp/ItBookSearchApp/DetailViewController.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 class DetailViewController: UIViewController {
+    let bookISBN13: String
     var itBookDetailManager: ItBookDetailManager?
     var itBookDetail: ItBookDetail?
     
@@ -169,11 +170,23 @@ class DetailViewController: UIViewController {
         return button
     }()
     
+    init(isbn13: String) {
+        self.bookISBN13 = isbn13
+        
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
         view.backgroundColor = .systemBackground
         setupLayout()
+        
+        requestItBookDetail(from: bookISBN13)
     }
 }
 
@@ -279,7 +292,7 @@ extension DetailViewController {
                     self.yearLabel.text = "Year: \(bookDetail.year)"
                     self.ratingLabel.text = "Rating: \(bookDetail.rating)"
                     self.descriptionLabel.text = "Description: \(bookDetail.desc)"
-                    self.priceLabel.text = "Price: $\(bookDetail.subtitle)"
+                    self.priceLabel.text = "Price: $\(bookDetail.price)"
                     self.urlLabel.text = "URL: \(bookDetail.url)"
                 }
             }

--- a/ItBookSearchApp/ItBookSearchApp/DetailViewController.swift
+++ b/ItBookSearchApp/ItBookSearchApp/DetailViewController.swift
@@ -259,9 +259,6 @@ extension DetailViewController {
                 self.itBookDetail = data
                 guard let bookDetail = self.itBookDetail else { return }
                 
-                self.firstPDFURL = bookDetail.pdf?.chapter2
-                self.secondPDFURL = bookDetail.pdf?.chapter5
-                
                 if let url = URL(string: bookDetail.imageURL) {
                     DispatchQueue.global().async {
                         if let imageData = try? Data(contentsOf: url) {

--- a/ItBookSearchApp/ItBookSearchApp/DetailViewController.swift
+++ b/ItBookSearchApp/ItBookSearchApp/DetailViewController.swift
@@ -14,7 +14,6 @@ class DetailViewController: UIViewController {
     
     private lazy var imageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.backgroundColor = .blue
         imageView.translatesAutoresizingMaskIntoConstraints = false
         
         return imageView

--- a/ItBookSearchApp/ItBookSearchApp/DetailViewController.swift
+++ b/ItBookSearchApp/ItBookSearchApp/DetailViewController.swift
@@ -8,6 +8,9 @@
 import UIKit
 
 class DetailViewController: UIViewController {
+    var itBookDetailManager: ItBookDetailManager?
+    var itBookDetail: ItBookDetail?
+    
     private lazy var imageView: UIImageView = {
         let imageView = UIImageView()
         imageView.backgroundColor = .blue
@@ -244,5 +247,46 @@ extension DetailViewController {
         secondPDFButton.trailingAnchor.constraint(equalTo: imageView.trailingAnchor).isActive = true
         secondPDFButton.widthAnchor.constraint(equalToConstant: 125.0).isActive = true
         secondPDFButton.heightAnchor.constraint(equalToConstant: 50.0).isActive = true
+    }
+    
+    //TODO: Unit Test 필요
+    func requestItBookDetail(from isbn13: String, by manager: ItBookDetailManager = ItBookDetailManager()) {
+        itBookDetailManager = manager
+        
+        itBookDetailManager?.requestItBookDetail(isbn13: isbn13) { [weak self] response in
+            guard let self = self else { return }
+            if case .success(let data) = response {
+                self.itBookDetail = data
+                guard let bookDetail = self.itBookDetail else { return }
+                
+                self.firstPDFURL = bookDetail.pdf?.chapter2
+                self.secondPDFURL = bookDetail.pdf?.chapter5
+                
+                if let url = URL(string: bookDetail.imageURL) {
+                    DispatchQueue.global().async {
+                        if let imageData = try? Data(contentsOf: url) {
+                            DispatchQueue.main.async {
+                                self.imageView.image = UIImage(data: imageData)
+                            }
+                        }
+                    }
+                }
+                
+                DispatchQueue.main.async {
+                    self.titleLabel.text = "Title: \(bookDetail.title)"
+                    self.subtitleLabel.text = "Subtitle: \(bookDetail.subtitle)"
+                    self.authorLabel.text = "Author: \(bookDetail.authors)"
+                    self.publisherLabel.text = "Publisher: \(bookDetail.authors)"
+                    self.isbn10Label.text = "ISBN10: \(bookDetail.isbn10)"
+                    self.isbn13Label.text = "ISBN13: \(bookDetail.isbn13)"
+                    self.pageLabel.text = "Page: \(bookDetail.pages)"
+                    self.yearLabel.text = "Year: \(bookDetail.year)"
+                    self.ratingLabel.text = "Rating: \(bookDetail.rating)"
+                    self.descriptionLabel.text = "Description: \(bookDetail.desc)"
+                    self.priceLabel.text = "Price: $\(bookDetail.subtitle)"
+                    self.urlLabel.text = "URL: \(bookDetail.url)"
+                }
+            }
+        }
     }
 }

--- a/ItBookSearchApp/ItBookSearchApp/DetailViewController.swift
+++ b/ItBookSearchApp/ItBookSearchApp/DetailViewController.swift
@@ -249,7 +249,6 @@ extension DetailViewController {
         secondPDFButton.heightAnchor.constraint(equalToConstant: 50.0).isActive = true
     }
     
-    //TODO: Unit Test 필요
     func requestItBookDetail(from isbn13: String, by manager: ItBookDetailManager = ItBookDetailManager()) {
         itBookDetailManager = manager
         

--- a/ItBookSearchApp/ItBookSearchApp/DetailViewController.swift
+++ b/ItBookSearchApp/ItBookSearchApp/DetailViewController.swift
@@ -14,6 +14,7 @@ class DetailViewController: UIViewController {
     
     private lazy var imageView: UIImageView = {
         let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
         imageView.translatesAutoresizingMaskIntoConstraints = false
         
         return imageView
@@ -21,7 +22,8 @@ class DetailViewController: UIViewController {
     
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: 20.0, weight: .bold)
+        label.font = .systemFont(ofSize: 16.0, weight: .bold)
+        label.numberOfLines = 2
         label.text = "Title : title"
         label.sizeToFit()
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -212,10 +214,11 @@ extension DetailViewController {
         imageView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 10.0).isActive = true
         imageView.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
         imageView.widthAnchor.constraint(equalToConstant: 300.0).isActive = true
-        imageView.heightAnchor.constraint(equalToConstant: 350.0).isActive = true
+        imageView.heightAnchor.constraint(equalToConstant: 200.0).isActive = true
         
         titleLabel.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: 10.0).isActive = true
         titleLabel.leadingAnchor.constraint(equalTo: imageView.leadingAnchor).isActive = true
+        titleLabel.trailingAnchor.constraint(equalTo: imageView.trailingAnchor).isActive = true
         
         subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 8.0).isActive = true
         subtitleLabel.leadingAnchor.constraint(equalTo: imageView.leadingAnchor).isActive = true
@@ -243,6 +246,7 @@ extension DetailViewController {
         
         descriptionLabel.topAnchor.constraint(equalTo: ratingLabel.bottomAnchor, constant: 8.0).isActive = true
         descriptionLabel.leadingAnchor.constraint(equalTo: imageView.leadingAnchor).isActive = true
+        descriptionLabel.trailingAnchor.constraint(equalTo: imageView.trailingAnchor).isActive = true
         
         priceLabel.topAnchor.constraint(equalTo: descriptionLabel.bottomAnchor, constant: 8.0).isActive = true
         priceLabel.leadingAnchor.constraint(equalTo: imageView.leadingAnchor).isActive = true

--- a/ItBookSearchApp/ItBookSearchApp/SearchViewController.swift
+++ b/ItBookSearchApp/ItBookSearchApp/SearchViewController.swift
@@ -92,6 +92,12 @@ extension SearchViewController: UICollectionViewDelegateFlowLayout {
         
         return CGSize(width: width, height: height)
     }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let detailViewController = DetailViewController()
+        
+        navigationController?.pushViewController(detailViewController, animated: true)
+    }
 }
 
 extension SearchViewController: UICollectionViewDataSource {

--- a/ItBookSearchApp/ItBookSearchApp/SearchViewController.swift
+++ b/ItBookSearchApp/ItBookSearchApp/SearchViewController.swift
@@ -94,7 +94,7 @@ extension SearchViewController: UICollectionViewDelegateFlowLayout {
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let detailViewController = DetailViewController()
+        let detailViewController = DetailViewController(isbn13: books[indexPath.row].isbn13)
         
         navigationController?.pushViewController(detailViewController, animated: true)
     }

--- a/ItBookSearchApp/ItBookSearchApp/SearchViewController.swift
+++ b/ItBookSearchApp/ItBookSearchApp/SearchViewController.swift
@@ -166,7 +166,6 @@ extension SearchViewController {
     }
     
     func setNavigationItems() {
-        navigationController?.navigationBar.prefersLargeTitles = true
         navigationItem.title = "ItBookSearch"
         
         let searchController = UISearchController()

--- a/ItBookSearchApp/ItBookSearchAppTests/DetailViewControllerTests.swift
+++ b/ItBookSearchApp/ItBookSearchAppTests/DetailViewControllerTests.swift
@@ -1,0 +1,93 @@
+//
+//  DetailViewControllerTests.swift
+//  ItBookSearchAppTests
+//
+//  Created by 이재웅 on 2022/11/12.
+//
+
+import XCTest
+@testable import ItBookSearchApp
+
+final class DetailViewControllerTests: XCTestCase {
+    var sut: DetailViewController!
+
+    override func setUpWithError() throws {
+        self.sut = DetailViewController()
+    }
+
+    override func tearDownWithError() throws {
+        sut = nil
+    }
+    
+    func test_requestItBookDetail_성공적으로_호출하면_itBookDetail에_데이터가_할당된다() {
+        // given
+        let isbn13 = "9781491985571"
+        let url = "https://api.itbook.store/1.0/books/\(isbn13)"
+        let data: Data? = JsonLoader.data(fileName: "FileWeb_Scraping_with_Python_ItBookDetail")
+        let mockURLSession = MockURLSession.make(
+            url: url, data: data, statusCode: 200)
+        let networkManager = ItBookDetailManager(session: mockURLSession)
+        
+        //when
+        var result: ItBookDetail?
+        sut.requestItBookDetail(from: isbn13, by: networkManager)
+        
+        result = sut.itBookDetail
+        
+        XCTAssertNotNil(result)
+    }
+    
+    func test_requestItBookDetail_호출실패하면_itBookDetail에_데이터는_nil() {
+        // given
+        let isbn13 = "9781491985571"
+        let url = "https://api.itbook.store/1.0/books/\(isbn13)"
+        let data: Data? = JsonLoader.data(fileName: "FileWeb_Scraping_with_Python_ItBookDetail")
+        let mockURLSession = MockURLSession.make(
+            url: url, data: data, statusCode: 500)
+        let networkManager = ItBookDetailManager(session: mockURLSession)
+        
+        //when
+        var result: ItBookDetail?
+        sut.requestItBookDetail(from: isbn13, by: networkManager)
+        
+        result = sut.itBookDetail
+        
+        XCTAssertNil(result)
+    }
+    
+    func test_requestItBookDetail_pdf없는_데이터_itBookDetail의_pdf_nil() {
+        // given
+        let isbn13 = "9781491985571"
+        let url = "https://api.itbook.store/1.0/books/\(isbn13)"
+        let data: Data? = JsonLoader.data(fileName: "FileWeb_Scraping_with_Python_ItBookDetail")
+        let mockURLSession = MockURLSession.make(
+            url: url, data: data, statusCode: 200)
+        let networkManager = ItBookDetailManager(session: mockURLSession)
+        
+        //when
+        var result: ItBookPDF?
+        sut.requestItBookDetail(from: isbn13, by: networkManager)
+        
+        result = sut.itBookDetail?.pdf
+        
+        XCTAssertNil(result)
+    }
+    
+    func test_requestItBookDetail_pdf있는_데이터_itBookDetail의_pdf_존재() {
+        // given
+        let isbn13 = "9781617294136"
+        let url = "https://api.itbook.store/1.0/books/\(isbn13)"
+        let data: Data? = JsonLoader.data(fileName: "Securing_DevOps_ItBookDetail")
+        let mockURLSession = MockURLSession.make(
+            url: url, data: data, statusCode: 200)
+        let networkManager = ItBookDetailManager(session: mockURLSession)
+        
+        //when
+        var result: ItBookPDF?
+        sut.requestItBookDetail(from: isbn13, by: networkManager)
+        
+        result = sut.itBookDetail?.pdf
+        
+        XCTAssertNotNil(result)
+    }
+}

--- a/ItBookSearchApp/ItBookSearchAppTests/SearchViewControllerTests.swift
+++ b/ItBookSearchApp/ItBookSearchAppTests/SearchViewControllerTests.swift
@@ -1,5 +1,5 @@
 //
-//  ViewControllerTests.swift
+//  SearchViewControllerTests.swift
 //  ItBookSearchAppTests
 //
 //  Created by 이재웅 on 2022/11/11.
@@ -8,7 +8,7 @@
 import XCTest
 @testable import ItBookSearchApp
 
-final class ViewController: XCTestCase {
+final class SearchViewController: XCTestCase {
     var sut: SearchViewController!
 
     override func setUpWithError() throws {

--- a/ItBookSearchApp/ItBookSearchAppTests/SearchViewControllerTests.swift
+++ b/ItBookSearchApp/ItBookSearchAppTests/SearchViewControllerTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 @testable import ItBookSearchApp
 
-final class SearchViewController: XCTestCase {
+final class SearchViewControllerTest: XCTestCase {
     var sut: SearchViewController!
 
     override func setUpWithError() throws {


### PR DESCRIPTION
## 작업사항
SearchViewController의 cell을 터치할 경우 해당 cell 데이터의 isbn13값을 받아 DetailViewController로 전환 후 requestItBookStorePagination를 통해 ITBookDetail 데이터 호출 및 UI에 데이터 기입을 구현하였습니다.

## 이슈번호
- #15 

## 특이사항(Optional)
PDF 데이터가 있을 경우 PDF 버튼이 활성화 되도록 구현해야합니다.

close #15 
