### PR TITLE
[2022/11/12] feat/memoryCacheLimit >> 메모리캐시 제한용량 50메가로 설정

### DIFF
--- a/ItBookSearchApp/ItBookSearchApp/ImageCache.swift
+++ b/ItBookSearchApp/ItBookSearchApp/ImageCache.swift
@@ -9,6 +9,9 @@ import UIKit
 
 class ImageCacheManager {
     static let shared = NSCache<NSString, UIImage>()
+    static func configureCachePolicy(with maximumBytes: Int) {
+        self.shared.totalCostLimit = maximumBytes
+    }
     
     private init() { }
 }

--- a/ItBookSearchApp/ItBookSearchApp/SceneDelegate.swift
+++ b/ItBookSearchApp/ItBookSearchApp/SceneDelegate.swift
@@ -19,6 +19,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         self.window?.rootViewController = UINavigationController(rootViewController: SearchViewController())
         self.window?.makeKeyAndVisible()
+        
+        ImageCacheManager.configureCachePolicy(with: 52428800)
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/ItBookSearchApp/ItBookSearchApp/URLUIImageView.swift
+++ b/ItBookSearchApp/ItBookSearchApp/URLUIImageView.swift
@@ -56,7 +56,7 @@ class URLUIImageView: UIImageView {
                 
                 DispatchQueue.main.async {
                     if let data = data, let image = UIImage(data: data) {
-                        ImageCacheManager.shared.setObject(image, forKey: cachedKey as NSString)
+                        ImageCacheManager.shared.setObject(image, forKey: cachedKey as NSString, cost: data.count)
                         self.image = image
                     }
                 }


### PR DESCRIPTION
## 작업사항
이미지 메모리캐시가 최대 50메가까지 저장되도록 구현하였습니다.

## 이슈번호
- #25 

close #25 