### PR TITLE
[2022/11/12] eat/diskCacheLimit >> 디스크 캐시 저장오류 수정 및 로직수정

### DIFF
--- a/ItBookSearchApp/ItBookSearchApp/URLUIImageView.swift
+++ b/ItBookSearchApp/ItBookSearchApp/URLUIImageView.swift
@@ -40,6 +40,8 @@ class URLUIImageView: UIImageView {
                     self.image = cachedImage
                     ImageCacheManager.shared.setObject(cachedImage, forKey: cachedKey as NSString)
                 }
+                
+                return
             }
 
             

--- a/ItBookSearchApp/ItBookSearchApp/URLUIImageView.swift
+++ b/ItBookSearchApp/ItBookSearchApp/URLUIImageView.swift
@@ -57,6 +57,7 @@ class URLUIImageView: UIImageView {
                 DispatchQueue.main.async {
                     if let data = data, let image = UIImage(data: data) {
                         ImageCacheManager.shared.setObject(image, forKey: cachedKey as NSString, cost: data.count)
+                        fileManager.createFile(atPath: filePath.path, contents: image.jpegData(compressionQuality: 1.0), attributes: nil)
                         self.image = image
                     }
                 }


### PR DESCRIPTION
## 작업사항
1. 이미지 URL을 호출하더라도 FileManger에 해당 데이터를 저장하지 않던 오류를 수정하였습니다.
2. 디스크캐시를 통해 이미지를 불러올 경우에 이미지를 불러왔음에도 URL 호출을 진행하던 로직을 수정하였습니다.

## 이슈번호
- #27 

## 특이사항(Optional)
디스크캐시 저장용량제한을 구현해야합니다.
